### PR TITLE
Add TTL on Rabbit publish & subscribe

### DIFF
--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/client.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/client.ts
@@ -12,8 +12,20 @@ export type AmqpCallbackType = (
 ) => void;
 
 export type PublishOptions = {
+  /**
+   * Published message TTL in ms.
+   * Up to the underlying layer to deal with it (if supported) and so to not deliver the message if expired.
+   */
   ttl?: number | null;
 };
+
+export type SubscribeOptions = {
+  /**
+   * Message TTL in ms.
+   * This value is used (if supported) by the underlying layer to not deliver message to the local subscriber if message expired.
+   */
+  ttl?: number | null;
+}
 
 /**
  * Low level AMQP client using AMQP channel the right way.
@@ -50,26 +62,36 @@ export class AmqpClient {
     exchange: string,
     type = CONSTANTS.EXCHANGE_TYPES.topic,
   ): Promise<Replies.AssertExchange> {
+    logger.debug(`${LOG_PREFIX} Assert exchange ${exchange} of type ${type}`);
     return this.channel.assertExchange(exchange, type);
   }
 
   ack(message: Message, allUpTo = false): void {
+    logger.debug(`${LOG_PREFIX} Ack message`);
     this.channel.ack(message, allUpTo);
   }
 
   assertQueue(name: string, options: Options.AssertQueue): Promise<Replies.AssertQueue> {
-    return this.channel.assertQueue(name, options);
-  }
+    logger.debug(`${LOG_PREFIX} Assert queue ${name} with options %o`, options);
+    return this.channel.assertQueue(name, options).then(result => {
+      logger.debug(`${LOG_PREFIX} Queue created %o`, result);
 
+      return result;
+    });
+  }
+  
   assertBinding(queue: string, exchange: string, routingPattern?: string): Promise<Replies.Empty> {
+    logger.debug(`${LOG_PREFIX} Bind queue ${queue} on exchange ${exchange} with pattern ${routingPattern}`);
     return this.channel.bindQueue(queue, exchange, routingPattern);
   }
-
+  
   send(exchange: string, data: unknown, routingKey = "", options?: Options.Publish): boolean {
+    logger.debug(`${LOG_PREFIX} Publish message to exchange ${exchange} with options %o`, options);
     return this.channel.publish(exchange, routingKey, dataAsBuffer(data), options);
   }
-
+  
   consume(queue: string, options: Options.Consume, callback: AmqpCallbackType): Promise<void> {
+    logger.debug(`${LOG_PREFIX} Consume queue ${queue} with options %o`, options);
     return this.channel
       .consume(queue, onMessage, options)
       .then(res => this._registerNewConsumerTag(callback, res.consumerTag, queue));

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/client.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/client.ts
@@ -11,6 +11,10 @@ export type AmqpCallbackType = (
   originalMessage: ConsumeMessage,
 ) => void;
 
+export type PublishOptions = {
+  ttl?: number | null;
+};
+
 /**
  * Low level AMQP client using AMQP channel the right way.
  *
@@ -61,8 +65,8 @@ export class AmqpClient {
     return this.channel.bindQueue(queue, exchange, routingPattern);
   }
 
-  send(exchange: string, data: unknown, routingKey = ""): boolean {
-    return this.channel.publish(exchange, routingKey, dataAsBuffer(data));
+  send(exchange: string, data: unknown, routingKey = "", options?: Options.Publish): boolean {
+    return this.channel.publish(exchange, routingKey, dataAsBuffer(data), options);
   }
 
   consume(queue: string, options: Options.Consume, callback: AmqpCallbackType): Promise<void> {

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/manager.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/manager.ts
@@ -33,8 +33,8 @@ export class AMQPPubsubManager implements PubsubClientManager {
 
     // Connect event is not sent on first connection
     // so we have to deal with the `connected` flag
-    connection.on("connect", () => {
-      logger.info(`${LOG_PREFIX} Connected to RabbitMQ`);
+    connection.on("connect", ({ url }) => {
+      logger.info(`${LOG_PREFIX} Connected to RabbitMQ on ${url}`);
       if (this.connected) {
         return;
       }

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsub.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsub.ts
@@ -18,7 +18,7 @@ export class AMQPPubSub implements PubsubClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async publish(topic: string, message: PubsubMessage<any>): Promise<void> {
     logger.debug(`${LOG_PREFIX} Publishing message to topic ${topic}`);
-    await this.client.publish(topic, message.data);
+    await this.client.publish(topic, message.data, { ttl: message.ttl });
   }
 
   subscribe(

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsub.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsub.ts
@@ -1,7 +1,7 @@
 import { logger } from "../../../framework/logger";
 import { AmqpPubsubClient } from "./pubsubclient";
 import { PubsubMessage, PubsubListener, PubsubClient, PubsubSubscriptionOptions } from "../api";
-import { AmqpCallbackType } from "./client";
+import { AmqpCallbackType, SubscribeOptions } from "./client";
 
 const LOG_PREFIX = "service.pubsub.amqp.AMQPPubSub -";
 
@@ -25,8 +25,9 @@ export class AMQPPubSub implements PubsubClient {
     topic: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: PubsubListener<any>,
-    options: PubsubSubscriptionOptions = { unique: false, queue: null },
+    options: PubsubSubscriptionOptions = { unique: false, queue: null, ttl: -1 },
   ): Promise<void> {
+    const subscribeOptions: SubscribeOptions = {};
     logger.debug(`${LOG_PREFIX} Subscribing to topic ${topic} with options %o`, options);
 
     const callback: AmqpCallbackType = (err, message, originalMessage) => {
@@ -45,8 +46,12 @@ export class AMQPPubSub implements PubsubClient {
       });
     };
 
+    if (options.ttl && options.ttl > 0) {
+      subscribeOptions.ttl = options.ttl;
+    }
+
     return options?.unique
-      ? this.client.subscribeToDurableQueue(topic, options?.queue || topic, callback)
-      : this.client.subscribe(topic, callback);
+      ? this.client.subscribeToDurableQueue(topic, options?.queue || topic, subscribeOptions, callback)
+      : this.client.subscribe(topic, subscribeOptions, callback);
   }
 }

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsubclient.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsubclient.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../../framework/logger";
 import { constants as CONSTANTS } from "./constants";
-import { AmqpClient, AmqpCallbackType, PublishOptions } from "./client";
+import { AmqpClient, AmqpCallbackType, PublishOptions, SubscribeOptions } from "./client";
 import { Options } from "amqplib";
 
 const LOG_PREFIX = "service.pubsub.amqp.AmqpPubsubClient -";
@@ -25,10 +25,15 @@ export class AmqpPubsubClient extends AmqpClient {
     );
   }
 
-  subscribe(topic: string, callback: AmqpCallbackType): Promise<void> {
+  subscribe(topic: string, options: SubscribeOptions, callback: AmqpCallbackType): Promise<void> {
+    const queueOptions: Options.AssertQueue = {
+      ...CONSTANTS.SUBSCRIBER.queueOptions,
+      ... options?.ttl ? { messageTtl: options.ttl } : {},
+    };
+
     return this.assertExchange(topic, CONSTANTS.PUBSUB_EXCHANGE.type)
       .then(() =>
-        this.assertQueue(CONSTANTS.SUBSCRIBER.queueName, CONSTANTS.SUBSCRIBER.queueOptions),
+        this.assertQueue(CONSTANTS.SUBSCRIBER.queueName, queueOptions),
       )
       .then(res => this.assertBinding(res.queue, topic).then(() => res))
       .then(res => this.consume(res.queue, CONSTANTS.SUBSCRIBER.consumeOptions, callback));
@@ -37,7 +42,7 @@ export class AmqpPubsubClient extends AmqpClient {
   /**
    * Creates a new consumer which asserts that it will listen to messages in a durable queue.
    * The durable queue goal is to be able to receive events 'from the past' ie events which has been push to the queue while subscribers were not bound.
-   * This is quite useful in case of ESN restart to not miss anything between stop and start.
+   * This is quite useful in case of restart to not miss anything between stop and start.
    * Important: If multiple consumers are connected to the same durable queue, AMQP will deliver message to one and only one consumer with a Round-robin behavior by default.
    *
    * @param {String} exchangeName - The exchange name
@@ -47,11 +52,18 @@ export class AmqpPubsubClient extends AmqpClient {
   subscribeToDurableQueue(
     exchangeName: string,
     queueName: string,
+    options: SubscribeOptions,
     callback: AmqpCallbackType,
   ): Promise<void> {
-    logger.debug(`${LOG_PREFIX} Subscribing to durable queue ${queueName}`);
+    const durableQueueOptions: Options.AssertQueue = {
+      ...CONSTANTS.SUBSCRIBER.durableQueueOptions,
+      ...options?.ttl ? { messageTtl: options.ttl } : {}
+    };
+
+    logger.debug(`${LOG_PREFIX} Subscribing to durable queue ${queueName} with options %o`, durableQueueOptions);
+    
     return this.assertExchange(exchangeName, CONSTANTS.PUBSUB_EXCHANGE.type)
-      .then(() => this.assertQueue(queueName, CONSTANTS.SUBSCRIBER.durableQueueOptions))
+      .then(() => this.assertQueue(queueName, durableQueueOptions))
       .then(() => this.assertBinding(queueName, exchangeName))
       .then(() => this.consume(queueName, CONSTANTS.SUBSCRIBER.consumeOptions, callback));
   }

--- a/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsubclient.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/amqp/pubsubclient.ts
@@ -1,6 +1,7 @@
 import { logger } from "../../../framework/logger";
 import { constants as CONSTANTS } from "./constants";
-import { AmqpClient, AmqpCallbackType } from "./client";
+import { AmqpClient, AmqpCallbackType, PublishOptions } from "./client";
+import { Options } from "amqplib";
 
 const LOG_PREFIX = "service.pubsub.amqp.AmqpPubsubClient -";
 
@@ -8,11 +9,19 @@ const LOG_PREFIX = "service.pubsub.amqp.AmqpPubsubClient -";
  * AMQP client abstracting low level channel methods to create a pubsub-like implementation
  */
 export class AmqpPubsubClient extends AmqpClient {
-  publish(topic: string, data: unknown): Promise<boolean> {
-    logger.debug(`${LOG_PREFIX} Publishing message to topic "${topic}"`);
+  publish(topic: string, data: unknown, options?: PublishOptions): Promise<boolean> {
+    let publishOptions: Options.Publish;
+
+    logger.debug(`${LOG_PREFIX} Publishing message to topic "${topic}" with options %o`, options);
+
+    if (options?.ttl) {
+      publishOptions = {
+        expiration: options.ttl
+      };
+    }
 
     return this.assertExchange(topic, CONSTANTS.PUBSUB_EXCHANGE.type).then(() =>
-      this.send(topic, data, CONSTANTS.PUBSUB_EXCHANGE.routingKey),
+      this.send(topic, data, CONSTANTS.PUBSUB_EXCHANGE.routingKey, publishOptions),
     );
   }
 

--- a/twake/backend/node/src/core/platform/services/pubsub/api.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/api.ts
@@ -41,9 +41,18 @@ export type PubsubSubscriptionOptions = {
   ack?: boolean;
 
   /**
-   * Use custom named queue instead of using same name as exchange
+   * Use custom named queue instead of using same name as exchange. Can be useful when we have multiple subsciptions on the same topic.
    */
   queue?: string | null;
+
+  /**
+   * Configures the message TTL (in ms) in the underlying messaging system.
+   * Negative or undefined means no TTL.
+   * Notes:
+   * - If supported by the messaging system, messages will not be delivered to the application.
+   * - If not supported, this may be up to the subscriber itself to filter messages at the application level based on some timestamp if available.
+   */
+  ttl?: number | null;
 };
 
 export type PubsubListener<T> = (message: IncomingPubsubMessage<T>) => void;

--- a/twake/backend/node/src/core/platform/services/pubsub/api.ts
+++ b/twake/backend/node/src/core/platform/services/pubsub/api.ts
@@ -10,6 +10,11 @@ export interface PubsubMessage<T> {
   id?: string;
 
   /**
+   * The message TTL period in milliseconds
+   */
+  ttl?: number;
+
+  /**
    * The message payload to process
    */
   data: T;


### PR DESCRIPTION
Note:
This can not be automatically applied to current production stuff: We need to do some manual operations before setting queues TTL because Rabbit will not like if we try to bind stuff with new properties.